### PR TITLE
Default fast_resume option to false

### DIFF
--- a/src/autotorrent/__main__.py
+++ b/src/autotorrent/__main__.py
@@ -60,7 +60,7 @@ cache_touched_files = false
 # rw_file_cache_chown = "1000:1000"
 rw_file_cache_ttl = 86400
 rw_file_cache_path = "/mnt/store_path/cache"
-fast_resume = true
+fast_resume = false
 ignore_file_patterns = [ ]
 
 [clients]


### PR DESCRIPTION
I strongly recommend removing the option to use fast-resume entirely, too often have I seen a single seeder that reports it has 100% but anyone who actually goes to download from them can only ever get 99%. Sometimes I've been that single seeder. This problem isn't only autotorrent's fault (there are plenty of tools that abuse rtorrent's fast resume), but it's the sole reason I stopped recommending the original tool.