### PR TITLE
Use os.scandir to reduce number of syscalls

### DIFF
--- a/src/autotorrent/indexer.py
+++ b/src/autotorrent/indexer.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from fnmatch import fnmatch
@@ -83,21 +84,21 @@ class Indexer:
     def _scan_path_thread(self, path, queue, root_thread=False):
         files = []
         try:
-            for p in path.iterdir():
+            for p in os.scandir(path):
                 if p.is_dir():
                     if self.ignore_directory_patterns and self._match_ignore_pattern(
-                        self.ignore_directory_patterns, p, ignore_case=True
+                        self.ignore_directory_patterns, Path(p), ignore_case=True
                     ):
                         continue
-                    self._scan_path_thread(p, queue)
+                    self._scan_path_thread(Path(p), queue)
                 elif p.is_file():
                     if self.ignore_file_patterns and self._match_ignore_pattern(
-                        self.ignore_file_patterns, p
+                        self.ignore_file_patterns, Path(p)
                     ):
                         continue
-                    files.append(p)
+                    files.append(Path(p))
                     size = p.stat().st_size
-                    queue.put((IndexAction.ADD, (p, size)))
+                    queue.put((IndexAction.ADD, (Path(p), size)))
 
             # TODO: probably not utf-8 problems resilient
             if is_unsplitable(files):  # TODO: prevent duplicate work (?)


### PR DESCRIPTION
True to the [PEP](https://peps.python.org/pep-0471/), this reduces the number of syscalls by roughly 1/3 on Linux.

I used `strace -f at2 scan|& grep <scanned path> | wc -l` to count the number of syscalls for a directory with 18155 files and 2101 directories (20256 entries total). On master, 58666 syscalls were issued, and with this change the new count is exactly 20256.

It can be merged completely independently of #41